### PR TITLE
Fix: Use relative paths for assets in HTML, CSS, and JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <title>Wirdak - Islamic Dhikr Habit Tracker</title>
     
     <!-- PWA Meta Tags -->
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="manifest.json">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Wirdak">
@@ -19,14 +19,14 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400;600;700&family=Noto+Sans+Arabic:wght@400;600;700&family=Noto+Naskh+Arabic&display=swap" rel="stylesheet">
     
     <!-- Stylesheets -->
-    <link rel="stylesheet" href="/css/main.css">
-    <link rel="stylesheet" href="/css/themes.css">
-    <link rel="stylesheet" href="/css/arabic.css">
-    <link rel="stylesheet" href="/css/animations.css">
+    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="css/themes.css">
+    <link rel="stylesheet" href="css/arabic.css">
+    <link rel="stylesheet" href="css/animations.css">
     
     <!-- Favicon -->
-    <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/favicon-32x32.png">
-    <link rel="apple-touch-icon" href="/assets/icons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/icons/favicon-32x32.png">
+    <link rel="apple-touch-icon" href="assets/icons/apple-touch-icon.png">
 </head>
 <body class="light-theme">
     <!-- Loading Spinner -->
@@ -42,7 +42,7 @@
     <nav class="navbar">
         <div class="container">
             <a href="#" class="navbar-brand">
-                <img src="/assets/icons/logo.svg" alt="Wirdak" width="32" height="32">
+                <img src="assets/icons/logo.svg" alt="Wirdak" width="32" height="32">
                 <span>Wirdak</span>
             </a>
             
@@ -672,21 +672,21 @@
     </div>
 
     <!-- Scripts -->
-    <script src="/js/storage.js"></script>
-    <script src="/js/adhkar-data.js"></script>
-    <script src="/js/export-import.js"></script>
-    <script src="/js/notifications.js"></script>
-    <script src="/js/counter-animation.js"></script>
-    <script src="/js/quran-tracker.js"></script>
-    <script src="/js/search.js"></script>
-    <script src="/js/social-share.js"></script>
-    <script src="/js/app.js"></script>
+    <script src="js/storage.js"></script>
+    <script src="js/adhkar-data.js"></script>
+    <script src="js/export-import.js"></script>
+    <script src="js/notifications.js"></script>
+    <script src="js/counter-animation.js"></script>
+    <script src="js/quran-tracker.js"></script>
+    <script src="js/search.js"></script>
+    <script src="js/social-share.js"></script>
+    <script src="js/app.js"></script>
     
     <!-- PWA Registration -->
     <script>
         if ('serviceWorker' in navigator) {
             window.addEventListener('load', () => {
-                navigator.serviceWorker.register('/service-worker.js')
+                navigator.serviceWorker.register('service-worker.js')
                     .then(registration => {
                         console.log('ServiceWorker registration successful with scope: ', registration.scope);
                     })

--- a/manifest.json
+++ b/manifest.json
@@ -2,20 +2,20 @@
   "name": "Wirdak - Islamic Dhikr Habit Tracker",
   "short_name": "Wirdak",
   "description": "Islamic habit tracking app for daily dhikr, Quran reading, and spiritual consistency",
-  "start_url": "/index.html",
+  "start_url": "index.html",
   "display": "standalone",
   "background_color": "#f8f9fa",
   "theme_color": "#10B981",
   "orientation": "portrait-primary",
   "icons": [
     {
-      "src": "/assets/icons/icon-192x192.png",
+      "src": "assets/icons/icon-192x192.png",
       "type": "image/png",
       "sizes": "192x192",
       "purpose": "any maskable"
     },
     {
-      "src": "/assets/icons/icon-512x512.png",
+      "src": "assets/icons/icon-512x512.png",
       "type": "image/png",
       "sizes": "512x512",
       "purpose": "any maskable"
@@ -26,15 +26,15 @@
       "name": "Morning Adhkar",
       "short_name": "Morning",
       "description": "Start your morning adhkar",
-      "url": "/index.html?category=morning",
-      "icons": [{ "src": "/assets/icons/morning-96x96.png", "sizes": "96x96" }]
+      "url": "index.html?category=morning",
+      "icons": [{ "src": "assets/icons/morning-96x96.png", "sizes": "96x96" }]
     },
     {
       "name": "Evening Adhkar",
       "short_name": "Evening",
       "description": "Start your evening adhkar",
-      "url": "/index.html?category=evening",
-      "icons": [{ "src": "/assets/icons/evening-96x96.png", "sizes": "96x96" }]
+      "url": "index.html?category=evening",
+      "icons": [{ "src": "assets/icons/evening-96x96.png", "sizes": "96x96" }]
     }
   ],
   "lang": "en",

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,27 +5,27 @@
 
 const CACHE_NAME = 'wirdak-cache-v1';
 const ASSETS_TO_CACHE = [
-  '/',
-  '/index.html',
-  '/manifest.json',
-  '/css/main.css',
-  '/css/themes.css',
-  '/css/arabic.css',
-  '/css/animations.css',
-  '/js/app.js',
-  '/js/storage.js',
-  '/js/export-import.js',
-  '/js/notifications.js',
-  '/js/adhkar-data.js',
-  '/js/quran-tracker.js',
-  '/js/search.js',
-  '/js/counter-animation.js',
-  '/js/social-share.js',
-  '/lang/ar.json',
-  '/lang/en.json',
-  '/data/hisn-al-muslim.json',
-  '/assets/icons/icon-192x192.png',
-  '/assets/icons/icon-512x512.png'
+  './',
+  'index.html',
+  'manifest.json',
+  'css/main.css',
+  'css/themes.css',
+  'css/arabic.css',
+  'css/animations.css',
+  'js/app.js',
+  'js/storage.js',
+  'js/export-import.js',
+  'js/notifications.js',
+  'js/adhkar-data.js',
+  'js/quran-tracker.js',
+  'js/search.js',
+  'js/counter-animation.js',
+  'js/social-share.js',
+  'lang/ar.json',
+  'lang/en.json',
+  'data/hisn-al-muslim.json',
+  'assets/icons/icon-192x192.png',
+  'assets/icons/icon-512x512.png'
 ];
 
 // Install event - cache assets
@@ -109,11 +109,11 @@ self.addEventListener('push', (event) => {
     
     const options = {
       body: data.body,
-      icon: '/assets/icons/icon-192x192.png',
-      badge: '/assets/icons/badge-96x96.png',
+      icon: 'assets/icons/icon-192x192.png',
+      badge: 'assets/icons/badge-96x96.png',
       vibrate: [100, 50, 100],
       data: {
-        url: data.url || '/'
+        url: data.url || './'
       }
     };
     


### PR DESCRIPTION
I've updated all internal asset links in index.html, service-worker.js, and manifest.json to use relative paths instead of absolute paths.

This resolves an issue where styles and JavaScript would not load correctly if you served the application from a subdirectory.